### PR TITLE
Update 100-JavaAppsLab.md

### DIFF
--- a/Java Apps/100-JavaAppsLab.md
+++ b/Java Apps/100-JavaAppsLab.md
@@ -8,7 +8,7 @@
 
 #### Create Database Connectivity on WebLogic Server ####
 
-1. [Sign in](sign.in.to.oracle.cloud.md) to [https://cloud.oracle.com/sign-in](https://cloud.oracle.com/sign-in) by provided **Java Cloud Service \(JCS\)** identity domain Id and credential. Using the dashboard open the Java Cloud Service Console.
+1. [Sign in](sign.in.to.oracle.cloud.md) to [https://cloud.oracle.com/sign-in](https://cloud.oracle.com/sign-in) by provided **Java Cloud Service \(JCS\)** identity domain Id and credential in the Access Document. Using the dashboard open the Java Cloud Service Console.
 
 ![](images/100/00.png)
 


### PR DESCRIPTION
@choichi 
- Added “in the Access Document” in the end of line of ‘<https://github.com/APACTestDrive/CloudNative_Mobile/compare/master...cholho-javaapps-100?quick_pull=1#diff-92bfd4b64d3d53fd1aa1fbdca168dbd7L11>' 
- Need to provide credentials for WebLogic.  We can put it in the access document, and give direction like “Please see Access Document for weblogic credentials.”
- How about adding some information on what participants are doing from the perspective of loyalty management. For example, we may add some information after Prerequisites as below:
### Accomplishment ###
- Through this lab, you will have a chance to create a DB connectivity between Java Application on JCS (Java Cloud Service) and DBMS on DB Cloud Service for loyalty management. (Sorry for my poor description here. I just give more information to participants because I’d like to make sure they are not lost.)